### PR TITLE
Fix link in team

### DIFF
--- a/docs/about/team.md
+++ b/docs/about/team.md
@@ -4,7 +4,7 @@ Fosshost is a UK Community Interest Company run entirely by volunteers. We do **
 
 The Fosshost Team consists of The Board of Directors, Senior Leadership Team and Capability Domain Owners (CDO) and Core Volunteers.  The Advisory Committee Board (ACB) is an independent committee that sits outside of our hierarchy with a Fosshost Representative attending each meeting.  
 
-Each volunteer is vitally essential, and we are each of equal importance. We contribute and share decisions collaboratively as much as possible. We are each empowered to contribute in our own unique and individual ways. As a project, we generate educational, academic, scientific, and research opportunities for aspiring individuals who have a passion for technology and drive to improve the open-source landscape. You can join the team by [offering to volunteer](/en/home/volunteering-opportunities).
+Each volunteer is vitally essential, and we are each of equal importance. We contribute and share decisions collaboratively as much as possible. We are each empowered to contribute in our own unique and individual ways. As a project, we generate educational, academic, scientific, and research opportunities for aspiring individuals who have a passion for technology and drive to improve the open-source landscape. You can join the team by [offering to volunteer](/about/volunteering-opportunities).
 
 ![](/assets/fosshost-orgchart-20211030.png)
 


### PR DESCRIPTION
It wasn't strictly "broken" but it was a redirect. This is faster.