### PR TITLE
Incorrect country code in docs/about/support.md

### DIFF
--- a/docs/about/support.md
+++ b/docs/about/support.md
@@ -12,7 +12,7 @@ In the first instance please always [submit](https://support.fossho.st) a suppor
 *   [Discord](https://discord.gg/C6VNFSHe4n)
 *   [IRC](https://web.libera.chat/#fosshost)
 *   UK Emergency Telephone Support: +44 (0) 208 154 4278 (call in emergency only)
-*   US Emergency Telephone Support: +001 (415) 610 7165 (call in emergency only)
+*   US Emergency Telephone Support: +1 (415) 610 7165 (call in emergency only)
 
 ## How to check service status
 


### PR DESCRIPTION
The US (NANP) country code is +1. 
Country codes starting with 0 don't exist. 00 is the escape code for the UK and much of the world.
So you would dial 00 and then you can dial a country code i.e. 1 for US (and the rest of the NANP).
However +1 is the proper country code for the US (NANP).