### PR TITLE
Remove (VPS) from x86 title

### DIFF
--- a/docs/products-and-services/virtual-private-server.md
+++ b/docs/products-and-services/virtual-private-server.md
@@ -1,4 +1,4 @@
-# x86 Virtual Private Server (VPS)
+# x86 Virtual Private Server
 
 
 When applying for our services, you can specify your preferred [region](/general/regions). This will typically be chosen on the following basis (this is not prescriptive):


### PR DESCRIPTION
It wasn't consistent with the other titles, and implies that x86 is vps but aarch is not.